### PR TITLE
SC-6506 Update CI chores

### DIFF
--- a/.github/scripts/SpaceKitSample-all_tests.sh
+++ b/.github/scripts/SpaceKitSample-all_tests.sh
@@ -7,7 +7,7 @@ cd SpaceKitSample
 xcodebuild -project SpaceKitSample.xcodeproj  \
     -scheme SpaceKitSample \
     -testPlan SpaceKitSampleTestPlan \
-    -destination platform=iOS\ Simulator,OS=16.0,name=iPhone\ 14\ Pro \
+    -destination platform=iOS\ Simulator,OS=16.2,name=iPhone\ 14\ Pro \
     clean test \
     | xcpretty
 

--- a/.github/workflows/SpaceKitSample_Tests.yml
+++ b/.github/workflows/SpaceKitSample_Tests.yml
@@ -7,6 +7,10 @@ on:
       - main
     workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
 

--- a/.github/workflows/SpaceKitSample_Tests.yml
+++ b/.github/workflows/SpaceKitSample_Tests.yml
@@ -8,13 +8,13 @@ on:
     workflow_dispatch:
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
 
 jobs:
       Test:
         if: github.event.pull_request.draft == false
         name: Test
-        runs-on: macos-12
+        runs-on: macos-13
         timeout-minutes: 60
 
         steps:

--- a/.github/workflows/Update_Cocoapod.yml
+++ b/.github/workflows/Update_Cocoapod.yml
@@ -24,7 +24,7 @@ jobs:
 
   Update_Cocoapod:
     name: Update podspec version
-    runs-on: macos-12
+    runs-on: macos-13
     needs: changes
     if: ${{ needs.changes.outputs.framework == 'true' }}
     timeout-minutes: 60


### PR DESCRIPTION
- Bump from Xcode 14.0 to Xcode 14.2 and macOS 12 to macOS 13
- Use GitHub Workflows concurrency on SpaceKitSample tests workflow, to cancel the unnecessary run that can result before the branch is rebased